### PR TITLE
fix: ban use of square brackets

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -56,10 +56,10 @@
 #' @noRd
 .get_encode_dictionary <- function() {
   encode_list <- list(
-    input = c("(", ")", "\"", ",", " ", ":", "!", "&", "|", "'", "[", "]", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
+    input = c("(", ")", "\"", ",", " ", ":", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
     output = c(
       "$LB$", "$RB$", "$QUOTE$", "$COMMA$", "$SPACE$", "$COLON$", "$EXCL$", "$AND$", "$OR$",
-      "$APO$", "$LSQ$", "$RSQ", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$"
+      "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$"
     )
   )
   return(encode_list)

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -77,14 +77,14 @@
     </div>
 
 
-    <p>Cadman T, Slofstra M, Wheater S, Avraam D (2024).
+    <p>Cadman T, Slofstra M, Wheater S, Avraam D (2025).
 <em>dsTidyverseClient: 'DataSHIELD' 'Tidyverse' Clientside Package</em>.
 R package version 1.0.0. 
 </p>
     <pre>@Manual{,
   title = {dsTidyverseClient: 'DataSHIELD' 'Tidyverse' Clientside Package},
   author = {Tim Cadman and Mariska Slofstra and Stuart Wheater and Demetris Avraam},
-  year = {2024},
+  year = {2025},
   note = {R package version 1.0.0},
 }</pre>
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,7 +1,7 @@
-pandoc: 3.1.11
+pandoc: '3.2'
 pkgdown: 2.0.9
 pkgdown_sha: ~
 articles:
   dstidyverse: dstidyverse.html
-last_built: 2024-11-04T14:18Z
+last_built: 2025-02-11T11:11Z
 

--- a/docs/reference/ds.case_when.html
+++ b/docs/reference/ds.case_when.html
@@ -114,7 +114,7 @@ RHS inputs in <code>tidy_expr</code> is created on the server.</p>
 <span class="r-in"><span><span class="co">## First log in to a DataSHIELD session with mtcars dataset loaded.</span></span></span>
 <span class="r-in"><span></span></span>
 <span class="r-in"><span><span class="fu">ds.case_when</span><span class="op">(</span></span></span>
-<span class="r-in"><span>  tidy_select <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html" class="external-link">list</a></span><span class="op">(</span></span></span>
+<span class="r-in"><span>  tidy_expr <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html" class="external-link">list</a></span><span class="op">(</span></span></span>
 <span class="r-in"><span>    <span class="va">mtcars</span><span class="op">$</span><span class="va">mpg</span> <span class="op">&lt;</span> <span class="fl">10</span> <span class="op">~</span> <span class="st">"low"</span>,</span></span>
 <span class="r-in"><span>    <span class="va">mtcars</span><span class="op">$</span><span class="va">mpg</span> <span class="op">&gt;=</span> <span class="fl">10</span> <span class="op">&amp;</span> <span class="va">mtcars</span><span class="op">$</span><span class="va">mpg</span> <span class="op">&lt;</span> <span class="fl">20</span> <span class="op">~</span> <span class="st">"medium"</span>,</span></span>
 <span class="r-in"><span>    <span class="va">mtcars</span><span class="op">$</span><span class="va">mpg</span> <span class="op">&gt;=</span> <span class="fl">20</span> <span class="op">~</span> <span class="st">"high"</span></span></span>

--- a/docs/reference/ds.filter.html
+++ b/docs/reference/ds.filter.html
@@ -109,7 +109,7 @@ with the name specified by <code>newobj</code> is created on the server.</p>
     <div class="sourceCode"><pre class="sourceCode r"><code><span class="r-in"><span><span class="kw">if</span> <span class="op">(</span><span class="cn">FALSE</span><span class="op">)</span> <span class="op">{</span></span></span>
 <span class="r-in"><span><span class="fu">ds.filter</span><span class="op">(</span></span></span>
 <span class="r-in"><span>  df.name <span class="op">=</span> <span class="st">"mtcars"</span>,</span></span>
-<span class="r-in"><span>  expr <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html" class="external-link">list</a></span><span class="op">(</span><span class="va">cyl</span> <span class="op">==</span> <span class="fl">4</span> <span class="op">&amp;</span> <span class="va">mpg</span> <span class="op">&gt;</span> <span class="fl">20</span><span class="op">)</span>,</span></span>
+<span class="r-in"><span>  tidy_expr <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/list.html" class="external-link">list</a></span><span class="op">(</span><span class="va">cyl</span> <span class="op">==</span> <span class="fl">4</span> <span class="op">&amp;</span> <span class="va">mpg</span> <span class="op">&gt;</span> <span class="fl">20</span><span class="op">)</span>,</span></span>
 <span class="r-in"><span>  newobj <span class="op">=</span> <span class="st">"filtered"</span>,</span></span>
 <span class="r-in"><span>  datasources <span class="op">=</span> <span class="va">conns</span></span></span>
 <span class="r-in"><span><span class="op">)</span></span></span>

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -70,14 +70,14 @@ test_that("ds.select correctly passes `matches`", {
   skip_if_not_installed("dsBaseClient")
   ds.select(
     df.name = "mtcars",
-    tidy_expr = list(matches("[aeiou]")),
+    tidy_expr = list(matches("a")),
     newobj = "matches",
     datasources = conns
   )
 
   expect_equal(
     ds.colnames("matches", datasources = conns)[[1]],
-    c("disp", "drat", "qsec", "am", "gear", "carb")
+    c("drat", "am", "gear", "carb")
   )
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -75,10 +75,10 @@ test_that(".set_new_obj defaults to .data if no new object name is provided", {
 
 test_that(".get_encode_dictionary returns the expected encoding key", {
   expected_encode_list <- list(
-    input = c("(", ")", "\"", ",", " ", ":", "!", "&", "|", "'", "[", "]", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
+    input = c("(", ")", "\"", ",", " ", ":", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
     output = c(
       "$LB$", "$RB$", "$QUOTE$", "$COMMA$", "$SPACE$", "$COLON$", "$EXCL$", "$AND$", "$OR$",
-      "$APO$", "$LSQ$", "$RSQ", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$",
+      "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$",
       "$GT$", "$LT$", "$TILDE$", "$LINE$"
     )
   )


### PR DESCRIPTION
## How to test
- [ ] Code review
- [ ] Check CI green

Assuming mtcars is on the server, assign it
Then:

`ds.bind_rows(to_combine = list(mtcars[1, ], mtcars[1, ], mtcars[1, ]), newobj = "test")`
This should throw an error