### PR TITLE
test: added end-to-end test for as.Data in mutate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     - run:
         name: Install R deps takes 15min, but no worries we skipinstalled from cache when this PR has installed them before
         command: |
-          Rscript -e 'install.packages(c("devtools", "pkgdown", "markdown", "rmarkdown", "rlang", "stringr", "cli", "covr", "git2r", "DSI", "assertthat", "purrr", "gridExtra", "DSLite", "RANN", "lme4", "reshape2", "polycor", "gamlss", "gamlss", "mice", "childsds", "fields", "metafor", "meta", "panelaggregation", "testthat"), repos = "https://cloud.r-project.org")'
+          Rscript -e 'install.packages(c("knitr", "devtools", "pkgdown", "markdown", "rmarkdown", "rlang", "stringr", "cli", "covr", "git2r", "DSI", "assertthat", "purrr", "gridExtra", "DSLite", "RANN", "lme4", "reshape2", "polycor", "gamlss", "gamlss", "mice", "childsds", "fields", "metafor", "meta", "panelaggregation", "testthat"), repos = "https://cloud.r-project.org")'
           Rscript -e 'install.packages(c("dsBase", "dsBaseClient"), repos = "https://cran.obiba.org/")'
           Rscript -e "git2r::config(user.email = 'molgenis+ci@gmail.com', user.name = 'MOLGENIS Jenkins')"
           if [ "$CIRCLE_BRANCH" != "master" ] && git ls-remote --heads https://github.com/molgenis/ds-tidyverse | grep "refs/heads/$CIRCLE_BRANCH"; then

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -106,3 +106,23 @@ test_that("ds.mutate passes with different .after argument", {
     c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "mpg_trans", "new_var", "vs", "am", "gear", "carb")
   )
 })
+
+date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
+date_login_data <- .prepare_dslite(assign_method = "mutateDS", tables = list(date_df = date_df))
+date_conns <- datashield.login(logins = date_login_data)
+datashield.assign.table(date_conns, "date_df", "date_df")
+
+test_that("ds.mutate passes with as.Date on a character column", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate(
+    df.name = "date_df",
+    tidy_expr = list(date_col = as.Date(date_str)),
+    newobj = "date_result",
+    datasources = date_conns
+  )
+
+  expect_equal(
+    ds.class("date_result$date_col", datasources = date_conns)[[1]],
+    "Date"
+  )
+})

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -109,8 +109,8 @@ test_that("ds.mutate passes with different .after argument", {
 
 date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
 date_login_data <- .prepare_dslite(assign_method = "mutateDS", tables = list(date_df = date_df))
-date_conns <- datashield.login(logins = date_login_data)
-datashield.assign.table(date_conns, "date_df", "date_df")
+conns <- datashield.login(logins = date_login_data)
+datashield.assign.table(conns, "date_df", "date_df")
 
 test_that("ds.mutate passes with as.Date on a character column", {
   skip_if_not_installed("dsBaseClient")
@@ -118,11 +118,11 @@ test_that("ds.mutate passes with as.Date on a character column", {
     df.name = "date_df",
     tidy_expr = list(date_col = as.Date(date_str)),
     newobj = "date_result",
-    datasources = date_conns
+    datasources = conns
   )
 
   expect_equal(
-    ds.class("date_result$date_col", datasources = date_conns)[[1]],
+    ds.class("date_result$date_col", datasources = conns)[[1]],
     "Date"
   )
 })


### PR DESCRIPTION
## Checklist for developing new functions
- [x] Write clientside function
- [x] Write serverside function
- [x] Evaluate whether additional disclosure checks are required, and if so write them
- [x] Update .circleci/config.yml so that CI installs 'molgenis/tidyverse' from corresponding branch
- [x] Add serverside function to inst/DATASHIELD file
- [x] On clientside package run `devtools::check()`. Review and fix any broken tests. 
- [x] On serverside package run `devtools::check()`. Review and fix any broken tests. 
- [x] Add new clientside tests to 'tests/testthat'
- [x] Add new serverside tests to 'tests/testthat'
- [x] Update clientside README.md to list function as included 
- [x] Update clientside vignette with example(s) of new function use
- [x] Check clientside function documentation is correct and complete
- [x] Check serverside function documentation is correct and complete
- [x] On clientside package run `devtools::check()` and `devtools::build_site()`
- [x] On serverside package run `devtools::check()` and `devtools::build_site()`

## How to test
- [x] Pull feat/as-date branch from molgenis/dsTidyverseClient
- [x] Pull feat/as-date branch from molgenis/dsTidyverse
- [x] Run: `devtools::load_all(path-to-clientside-package)`
- [x] Start Armadillo on localhost
- [x] Start basic profile
- [x] Install package on server:

```
devtools::build(path-to-serverside-package)
local_url <- "http://localhost:8080"
armadillo.login(local_url)
armadillo.install_packages(path-to-built-serverside-package, profile = "xenon")
```

- [x] Upload test data:
```
date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
armadillo.create_project("tidyverse")
armadillo.upload_table("tidyverse", "data", date_df)
```

- [x] Log in and assign data:
```
token <- armadillo.get_token(local_url)
builder <- newDSLoginBuilder()

builder$append(
  url = local_url,
  server = "cohort_1",
  token = token,
  driver = "ArmadilloDriver",
  profile = "xenon")

builder$append(
  url = local_url,
  server = "cohort_2",
  token = token,
  driver = "ArmadilloDriver",
  profile = "xenon")

builder$append(
  url = local_url,
  server = "cohort_3",
  token = token,
  driver = "ArmadilloDriver",
  profile = "xenon")

logindata <- builder$build()
conns <- datashield.login(logins = logindata, assign = FALSE)

datashield.assign(
  symbol = "date_df",
  value = "tidyverse/data/date_df",
  conns = conns)
```

- [x] Run the test lines 115 - 128 for `tests/testthat/test-mutate.R` Ignore the setting up a DSLite environment.

In addition:
- [ ] run `devtools::check()
