### PR TITLE
feat: add % encoding for date formats and expand test coverage for permitted functions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,5 @@ CONTRIBUTING.md
 ^pull_request_template$
 ^cran-comments\.md$
 ^LICENSE\.md$
+^\.claude$
+^\.idea$

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     - run:
         name: Install R deps takes 15min, but no worries we skipinstalled from cache when this PR has installed them before
         command: |
-          Rscript -e 'install.packages(c("devtools", "pkgdown", "markdown", "rmarkdown", "rlang", "stringr", "cli", "covr", "git2r", "DSI", "assertthat", "purrr", "gridExtra", "DSLite", "RANN", "lme4", "reshape2", "polycor", "gamlss", "gamlss", "mice", "childsds", "fields", "metafor", "meta", "panelaggregation", "testthat"), repos = "https://cloud.r-project.org")'
+          Rscript -e 'install.packages(c("knitr", "devtools", "pkgdown", "markdown", "rmarkdown", "rlang", "stringr", "cli", "covr", "git2r", "DSI", "assertthat", "purrr", "gridExtra", "DSLite", "RANN", "lme4", "reshape2", "polycor", "gamlss", "gamlss", "mice", "childsds", "fields", "metafor", "meta", "panelaggregation", "testthat"), repos = "https://cloud.r-project.org")'
           Rscript -e 'install.packages(c("dsBase", "dsBaseClient"), repos = "https://cran.obiba.org/")'
           Rscript -e "git2r::config(user.email = 'molgenis+ci@gmail.com', user.name = 'MOLGENIS Jenkins')"
           if [ "$CIRCLE_BRANCH" != "master" ] && git ls-remote --heads https://github.com/molgenis/ds-tidyverse | grep "refs/heads/$CIRCLE_BRANCH"; then

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 .DS_Store
 .Rproj.user
+.idea/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: Implementation of selected 'Tidyverse' functions within 'DataSHIELD
 License: LGPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports:
   DSI (>= 1.7.0),
   cli,

--- a/R/utils.R
+++ b/R/utils.R
@@ -56,10 +56,10 @@
 #' @noRd
 .get_encode_dictionary <- function() {
   encode_list <- list(
-    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
+    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n", "%"),
     output = c(
       "$LB$", "$RB$", "$QUOTE$", "$COMMA$", "$SPACE$", "$EXCL$", "$AND$", "$OR$",
-      "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$"
+      "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$", "$PCT$"
     )
   )
   return(encode_list)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -21,7 +21,20 @@
 #' @importFrom DSI newDSLoginBuilder
 #' @export
 .prepare_dslite <- function(assign_method = NULL, aggregate_method = NULL, tables = NULL) {
-  options(datashield.env = environment())
+  options(
+    datashield.env = environment(),
+    datashield.privacyControlLevel = "banana",
+    nfilter.tab = 3,
+    nfilter.subset = 3,
+    nfilter.glm = 0.33,
+    nfilter.string = 80,
+    nfilter.stringShort = 20,
+    nfilter.kNN = 3,
+    nfilter.levels.density = 0.33,
+    nfilter.levels.max = 40,
+    nfilter.noise = 0.25,
+    nfilter.privacy.old = 5
+  )
   dslite.server <- DSLite::newDSLiteServer(tables = tables)
   dslite.server$config(defaultDSConfiguration(include = c("dsBase", "dsTidyverse")))
   dslite.server$aggregateMethod("exists", "base::exists")

--- a/tests/testthat/test-mutate-permitted-functions.R
+++ b/tests/testthat/test-mutate-permitted-functions.R
@@ -5,18 +5,38 @@ require(dsTidyverse)
 require(dsBaseClient)
 
 data(mtcars)
-pf_na_df <- data.frame(x = c(1, NA, 3, NA, 5), stringsAsFactors = FALSE)
-pf_date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
-pf_date_dmy_df <- data.frame(date_str = c("15/01/2024", "30/06/2024", "25/12/2024"), stringsAsFactors = FALSE)
-pf_login_data <- .prepare_dslite(
+na_df <- data.frame(x = c(1, NA, 3, NA, 5), stringsAsFactors = FALSE)
+date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
+date_dmy_df <- data.frame(date_str = c("15/01/2024", "30/06/2024", "25/12/2024"), stringsAsFactors = FALSE)
+date_mdy_df <- data.frame(date_str = c("01/15/2024", "06/30/2024", "12/25/2024"), stringsAsFactors = FALSE)
+date_dmy_dash_df <- data.frame(date_str = c("15-01-2024", "30-06-2024", "25-12-2024"), stringsAsFactors = FALSE)
+date_ymd_slash_df <- data.frame(date_str = c("2024/01/15", "2024/06/30", "2024/12/25"), stringsAsFactors = FALSE)
+date_dby_df <- data.frame(date_str = c("15 Jan 2024", "30 Jun 2024", "25 Dec 2024"), stringsAsFactors = FALSE)
+date_bdy_df <- data.frame(date_str = c("Jan 15, 2024", "Jun 30, 2024", "Dec 25, 2024"), stringsAsFactors = FALSE)
+date_compact_df <- data.frame(date_str = c("20240115", "20240630", "20241225"), stringsAsFactors = FALSE)
+date_dot_df <- data.frame(date_str = c("15.01.2024", "30.06.2024", "25.12.2024"), stringsAsFactors = FALSE)
+login_data <- .prepare_dslite(
   assign_method = "mutateDS",
-  tables = list(mtcars = mtcars, pf_na_df = pf_na_df, pf_date_df = pf_date_df, pf_date_dmy_df = pf_date_dmy_df)
+  tables = list(
+    mtcars = mtcars, na_df = na_df, date_df = date_df,
+    date_dmy_df = date_dmy_df, date_mdy_df = date_mdy_df,
+    date_dmy_dash_df = date_dmy_dash_df, date_ymd_slash_df = date_ymd_slash_df,
+    date_dby_df = date_dby_df, date_bdy_df = date_bdy_df,
+    date_compact_df = date_compact_df, date_dot_df = date_dot_df
+  )
 )
-conns <- datashield.login(logins = pf_login_data)
+conns <- datashield.login(logins = login_data)
 datashield.assign.table(conns, "mtcars", "mtcars")
-datashield.assign.table(conns, "pf_na_df", "pf_na_df")
-datashield.assign.table(conns, "pf_date_df", "pf_date_df")
-datashield.assign.table(conns, "pf_date_dmy_df", "pf_date_dmy_df")
+datashield.assign.table(conns, "na_df", "na_df")
+datashield.assign.table(conns, "date_df", "date_df")
+datashield.assign.table(conns, "date_dmy_df", "date_dmy_df")
+datashield.assign.table(conns, "date_mdy_df", "date_mdy_df")
+datashield.assign.table(conns, "date_dmy_dash_df", "date_dmy_dash_df")
+datashield.assign.table(conns, "date_ymd_slash_df", "date_ymd_slash_df")
+datashield.assign.table(conns, "date_dby_df", "date_dby_df")
+datashield.assign.table(conns, "date_bdy_df", "date_bdy_df")
+datashield.assign.table(conns, "date_compact_df", "date_compact_df")
+datashield.assign.table(conns, "date_dot_df", "date_dot_df")
 
 # Math functions
 
@@ -207,7 +227,7 @@ test_that("ds.mutate permits as.numeric()", {
 
 test_that("ds.mutate permits as.Date() with ISO format", {
   skip_if_not_installed("dsBaseClient")
-  ds.mutate("pf_date_df", tidy_expr = list(new_col = as.Date(date_str)), newobj = "res", datasources = conns)
+  ds.mutate("date_df", tidy_expr = list(new_col = as.Date(date_str)), newobj = "res", datasources = conns)
   expect_equal(
     ds.class("res$new_col", datasources = conns)[[1]],
     "Date"
@@ -216,7 +236,7 @@ test_that("ds.mutate permits as.Date() with ISO format", {
 
 test_that("ds.mutate permits as.Date() with positional format argument", {
   skip_if_not_installed("dsBaseClient")
-  ds.mutate("pf_date_dmy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%d/%m/%Y"))), newobj = "res", datasources = conns)
+  ds.mutate("date_dmy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%d/%m/%Y"))), newobj = "res", datasources = conns)
   expect_equal(
     round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
     round(mean(as.numeric(as.Date(c("15/01/2024", "30/06/2024", "25/12/2024"), "%d/%m/%Y"))), 2)
@@ -225,10 +245,73 @@ test_that("ds.mutate permits as.Date() with positional format argument", {
 
 test_that("ds.mutate as.Date() without format gives wrong result for non-ISO dates", {
   skip_if_not_installed("dsBaseClient")
-  ds.mutate("pf_date_dmy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str))), newobj = "res_wrong", datasources = conns)
+  ds.mutate("date_dmy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str))), newobj = "res_wrong", datasources = conns)
   correct_mean <- round(mean(as.numeric(as.Date(c("15/01/2024", "30/06/2024", "25/12/2024"), "%d/%m/%Y"))), 2)
   wrong_mean <- round(ds.mean("res_wrong$date_num", datasources = conns)$Mean.by.Study[1, 1], 2)
   expect_false(wrong_mean == correct_mean)
+})
+
+test_that("ds.mutate permits as.Date() with US format %m/%d/%Y", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("date_mdy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%m/%d/%Y"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("01/15/2024", "06/30/2024", "12/25/2024"), "%m/%d/%Y"))), 2)
+  )
+})
+
+test_that("ds.mutate permits as.Date() with dash format %d-%m-%Y", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("date_dmy_dash_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%d-%m-%Y"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("15-01-2024", "30-06-2024", "25-12-2024"), "%d-%m-%Y"))), 2)
+  )
+})
+
+test_that("ds.mutate permits as.Date() with %Y/%m/%d format", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("date_ymd_slash_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%Y/%m/%d"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("2024/01/15", "2024/06/30", "2024/12/25"), "%Y/%m/%d"))), 2)
+  )
+})
+
+test_that("ds.mutate permits as.Date() with abbreviated month %d %b %Y", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("date_dby_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%d %b %Y"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("15 Jan 2024", "30 Jun 2024", "25 Dec 2024"), "%d %b %Y"))), 2)
+  )
+})
+
+test_that("ds.mutate permits as.Date() with %b %d, %Y format", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("date_bdy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%b %d, %Y"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("Jan 15, 2024", "Jun 30, 2024", "Dec 25, 2024"), "%b %d, %Y"))), 2)
+  )
+})
+
+test_that("ds.mutate permits as.Date() with compact %Y%m%d format", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("date_compact_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%Y%m%d"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("20240115", "20240630", "20241225"), "%Y%m%d"))), 2)
+  )
+})
+
+test_that("ds.mutate permits as.Date() with dot format %d.%m.%Y", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("date_dot_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%d.%m.%Y"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("15.01.2024", "30.06.2024", "25.12.2024"), "%d.%m.%Y"))), 2)
+  )
 })
 
 # Window functions
@@ -255,7 +338,7 @@ test_that("ds.mutate permits cumsum()", {
 
 test_that("ds.mutate permits is.na()", {
   skip_if_not_installed("dsBaseClient")
-  ds.mutate("pf_na_df", tidy_expr = list(new_col = is.na(x)), newobj = "res", datasources = conns)
+  ds.mutate("na_df", tidy_expr = list(new_col = is.na(x)), newobj = "res", datasources = conns)
   expect_equal(
     ds.class("res$new_col", datasources = conns)[[1]],
     "logical"
@@ -295,7 +378,7 @@ test_that("ds.mutate permits desc()", {
 
 test_that("ds.mutate permits as.numeric(as.Date()) nested call", {
   skip_if_not_installed("dsBaseClient")
-  ds.mutate("pf_date_df", tidy_expr = list(new_col = as.numeric(as.Date(date_str))), newobj = "res", datasources = conns)
+  ds.mutate("date_df", tidy_expr = list(new_col = as.numeric(as.Date(date_str))), newobj = "res", datasources = conns)
   expect_equal(
     round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
     round(mean(as.numeric(as.Date(c("2024-01-15", "2024-06-30", "2024-12-25")))), 2)

--- a/tests/testthat/test-mutate-permitted-functions.R
+++ b/tests/testthat/test-mutate-permitted-functions.R
@@ -1,0 +1,303 @@
+require(DSLite)
+require(DSI)
+require(dplyr)
+require(dsTidyverse)
+require(dsBaseClient)
+
+data(mtcars)
+pf_na_df <- data.frame(x = c(1, NA, 3, NA, 5), stringsAsFactors = FALSE)
+pf_date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
+pf_date_dmy_df <- data.frame(date_str = c("15/01/2024", "30/06/2024", "25/12/2024"), stringsAsFactors = FALSE)
+pf_login_data <- .prepare_dslite(
+  assign_method = "mutateDS",
+  tables = list(mtcars = mtcars, pf_na_df = pf_na_df, pf_date_df = pf_date_df, pf_date_dmy_df = pf_date_dmy_df)
+)
+conns <- datashield.login(logins = pf_login_data)
+datashield.assign.table(conns, "mtcars", "mtcars")
+datashield.assign.table(conns, "pf_na_df", "pf_na_df")
+datashield.assign.table(conns, "pf_date_df", "pf_date_df")
+datashield.assign.table(conns, "pf_date_dmy_df", "pf_date_dmy_df")
+
+# Math functions
+
+test_that("ds.mutate permits exp()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = exp(cyl)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(exp(mtcars$cyl)), 2)
+  )
+})
+
+test_that("ds.mutate permits sqrt()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = sqrt(hp)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(sqrt(mtcars$hp)), 2)
+  )
+})
+
+test_that("ds.mutate permits round()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = round(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1],
+    mean(round(mtcars$mpg))
+  )
+})
+
+test_that("ds.mutate permits floor()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = floor(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1],
+    mean(floor(mtcars$mpg))
+  )
+})
+
+test_that("ds.mutate permits ceiling()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = ceiling(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1],
+    mean(ceiling(mtcars$mpg))
+  )
+})
+
+test_that("ds.mutate permits abs()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = abs(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(abs(mtcars$mpg)), 2)
+  )
+})
+
+# Stats functions
+
+test_that("ds.mutate permits mean()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = mean(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(mtcars$mpg), 2)
+  )
+})
+
+test_that("ds.mutate permits median()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = median(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1],
+    median(mtcars$mpg)
+  )
+})
+
+test_that("ds.mutate permits sd()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = sd(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(sd(mtcars$mpg), 2)
+  )
+})
+
+test_that("ds.mutate permits var()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = var(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(var(mtcars$mpg), 2)
+  )
+})
+
+# Trig functions
+
+test_that("ds.mutate permits sin()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = sin(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(sin(mtcars$mpg)), 2)
+  )
+})
+
+test_that("ds.mutate permits cos()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = cos(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(cos(mtcars$mpg)), 2)
+  )
+})
+
+test_that("ds.mutate permits tan()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = tan(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(tan(mtcars$mpg)), 2)
+  )
+})
+
+test_that("ds.mutate permits asin()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = asin(mpg / 34)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(asin(mtcars$mpg / 34)), 2)
+  )
+})
+
+test_that("ds.mutate permits acos()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = acos(mpg / 34)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(acos(mtcars$mpg / 34)), 2)
+  )
+})
+
+test_that("ds.mutate permits atan()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = atan(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(atan(mtcars$mpg)), 2)
+  )
+})
+
+# Type conversion functions
+
+test_that("ds.mutate permits as.character()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = as.character(cyl)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.class("res$new_col", datasources = conns)[[1]],
+    "character"
+  )
+})
+
+test_that("ds.mutate permits as.integer()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = as.integer(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.class("res$new_col", datasources = conns)[[1]],
+    "integer"
+  )
+  expect_equal(
+    ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1],
+    mean(as.integer(mtcars$mpg))
+  )
+})
+
+test_that("ds.mutate permits as.numeric()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = as.numeric(cyl)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.class("res$new_col", datasources = conns)[[1]],
+    "numeric"
+  )
+  expect_equal(
+    ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1],
+    mean(as.numeric(mtcars$cyl))
+  )
+})
+
+test_that("ds.mutate permits as.Date() with ISO format", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("pf_date_df", tidy_expr = list(new_col = as.Date(date_str)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.class("res$new_col", datasources = conns)[[1]],
+    "Date"
+  )
+})
+
+test_that("ds.mutate permits as.Date() with positional format argument", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("pf_date_dmy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str, "%d/%m/%Y"))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$date_num", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("15/01/2024", "30/06/2024", "25/12/2024"), "%d/%m/%Y"))), 2)
+  )
+})
+
+test_that("ds.mutate as.Date() without format gives wrong result for non-ISO dates", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("pf_date_dmy_df", tidy_expr = list(date_num = as.numeric(as.Date(date_str))), newobj = "res_wrong", datasources = conns)
+  correct_mean <- round(mean(as.numeric(as.Date(c("15/01/2024", "30/06/2024", "25/12/2024"), "%d/%m/%Y"))), 2)
+  wrong_mean <- round(ds.mean("res_wrong$date_num", datasources = conns)$Mean.by.Study[1, 1], 2)
+  expect_false(wrong_mean == correct_mean)
+})
+
+# Window functions
+
+test_that("ds.mutate permits lag()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = lag(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(lag(mtcars$mpg), na.rm = TRUE), 2)
+  )
+})
+
+test_that("ds.mutate permits cumsum()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = cumsum(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(cumsum(mtcars$mpg)), 2)
+  )
+})
+
+# Logical and conditional functions
+
+test_that("ds.mutate permits is.na()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("pf_na_df", tidy_expr = list(new_col = is.na(x)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.class("res$new_col", datasources = conns)[[1]],
+    "logical"
+  )
+})
+
+test_that("ds.mutate permits if_else()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = if_else(mpg > 20, 1, 0)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 4),
+    round(mean(if_else(mtcars$mpg > 20, 1, 0)), 4)
+  )
+})
+
+test_that("ds.mutate permits case_when()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = case_when(cyl == 4 ~ "small", cyl == 6 ~ "medium", cyl == 8 ~ "large")), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.class("res$new_col", datasources = conns)[[1]],
+    "character"
+  )
+})
+
+# Other functions
+
+test_that("ds.mutate permits desc()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = desc(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    ds.class("res$new_col", datasources = conns)[[1]],
+    "numeric"
+  )
+})
+
+# Nested function calls (regression test for c( regex)
+
+test_that("ds.mutate permits as.numeric(as.Date()) nested call", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("pf_date_df", tidy_expr = list(new_col = as.numeric(as.Date(date_str))), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(as.numeric(as.Date(c("2024-01-15", "2024-06-30", "2024-12-25")))), 2)
+  )
+})

--- a/tests/testthat/test-mutate-permitted-functions.R
+++ b/tests/testthat/test-mutate-permitted-functions.R
@@ -374,6 +374,15 @@ test_that("ds.mutate permits desc()", {
   )
 })
 
+test_that("ds.mutate permits scale()", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate("mtcars", tidy_expr = list(new_col = scale(mpg)), newobj = "res", datasources = conns)
+  expect_equal(
+    round(ds.mean("res$new_col", datasources = conns)$Mean.by.Study[1, 1], 2),
+    round(mean(scale(mtcars$mpg)), 2)
+  )
+})
+
 # Nested function calls (regression test for c( regex)
 
 test_that("ds.mutate permits as.numeric(as.Date()) nested call", {

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -106,3 +106,23 @@ test_that("ds.mutate passes with different .after argument", {
     c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "mpg_trans", "new_var", "vs", "am", "gear", "carb")
   )
 })
+
+date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
+date_login_data <- .prepare_dslite(assign_method = "mutateDS", tables = list(date_df = date_df))
+date_conns <- datashield.login(logins = date_login_data)
+datashield.assign.table(date_conns, "date_df", "date_df")
+
+test_that("ds.mutate passes with as.Date on a character column", {
+  skip_if_not_installed("dsBaseClient")
+  ds.mutate(
+    df.name = "date_df",
+    tidy_expr = list(date_col = as.Date(date_str)),
+    newobj = "date_result",
+    datasources = date_conns
+  )
+
+  expect_equal(
+    ds.class("date_result$date_col", datasources = date_conns)[[1]],
+    "Date"
+  )
+})

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -106,23 +106,3 @@ test_that("ds.mutate passes with different .after argument", {
     c("mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "mpg_trans", "new_var", "vs", "am", "gear", "carb")
   )
 })
-
-date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
-date_login_data <- .prepare_dslite(assign_method = "mutateDS", tables = list(date_df = date_df))
-conns <- datashield.login(logins = date_login_data)
-datashield.assign.table(conns, "date_df", "date_df")
-
-test_that("ds.mutate passes with as.Date on a character column", {
-  skip_if_not_installed("dsBaseClient")
-  ds.mutate(
-    df.name = "date_df",
-    tidy_expr = list(date_col = as.Date(date_str)),
-    newobj = "date_result",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.class("date_result$date_col", datasources = conns)[[1]],
-    "Date"
-  )
-})

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -109,8 +109,8 @@ test_that("ds.mutate passes with different .after argument", {
 
 date_df <- data.frame(date_str = c("2024-01-15", "2024-06-30", "2024-12-25"), stringsAsFactors = FALSE)
 date_login_data <- .prepare_dslite(assign_method = "mutateDS", tables = list(date_df = date_df))
-date_conns <- datashield.login(logins = date_login_data)
-datashield.assign.table(date_conns, "date_df", "date_df")
+conns <- datashield.login(logins = date_login_data)
+datashield.assign.table(conns, "date_df", "date_df")
 
 test_that("ds.mutate passes with as.Date on a character column", {
   skip_if_not_installed("dsBaseClient")
@@ -118,11 +118,11 @@ test_that("ds.mutate passes with as.Date on a character column", {
     df.name = "date_df",
     tidy_expr = list(date_col = as.Date(date_str)),
     newobj = "date_result",
-    datasources = date_conns
+    datasources = conns
   )
 
   expect_equal(
-    ds.class("date_result$date_col", datasources = date_conns)[[1]],
+    ds.class("date_result$date_col", datasources = conns)[[1]],
     "Date"
   )
 })

--- a/tests/testthat/test-select-permitted-functions.R
+++ b/tests/testthat/test-select-permitted-functions.R
@@ -1,0 +1,177 @@
+require(DSLite)
+require(DSI)
+require(dplyr)
+require(dsTidyverse)
+require(dsBaseClient)
+
+data("mtcars")
+num_range_df <- data.frame(x1 = 1:5, x2 = 6:10, x3 = 11:15, y1 = 16:20, stringsAsFactors = FALSE)
+login_data <- .prepare_dslite(assign_method = "selectDS", tables = list(mtcars = mtcars, num_range_df = num_range_df))
+conns <- datashield.login(logins = login_data)
+datashield.assign.table(conns, "mtcars", "mtcars")
+datashield.assign.table(conns, "num_range_df", "num_range_df")
+
+test_that("ds.select correctly passes `starts_with`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(starts_with("m")),
+    newobj = "starts",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("starts", datasources = conns)[[1]],
+    "mpg"
+  )
+})
+
+test_that("ds.select correctly passes `ends_with`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(ends_with("m")),
+    newobj = "ends",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("ends", datasources = conns)[[1]],
+    "am"
+  )
+})
+
+test_that("ds.select correctly passes `matches`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(matches("a")),
+    newobj = "matches",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("matches", datasources = conns)[[1]],
+    c("drat", "am", "gear", "carb")
+  )
+})
+
+test_that("ds.select correctly passes `everything`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(everything()),
+    newobj = "everything",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("everything", datasources = conns)[[1]],
+    colnames(mtcars)
+  )
+})
+
+test_that("ds.select correctly passes `last_col`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(last_col()),
+    newobj = "last",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("last", datasources = conns)[[1]],
+    "carb"
+  )
+})
+
+test_that("ds.select correctly passes `group_cols`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(group_cols()),
+    newobj = "group",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("group", datasources = conns)[[1]],
+    character(0)
+  )
+})
+
+test_that("ds.select correctly passes `all_of`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(all_of(c("mpg", "cyl"))),
+    newobj = "all_of",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("all_of", datasources = conns)[[1]],
+    c("mpg", "cyl")
+  )
+})
+
+test_that("ds.select correctly passes `any_of`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(any_of(c("mpg", "cyl"))),
+    newobj = "any_of",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("any_of", datasources = conns)[[1]],
+    c("mpg", "cyl")
+  )
+})
+
+test_that("ds.select correctly passes `contains`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(contains("ra")),
+    newobj = "contains",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("contains", datasources = conns)[[1]],
+    "drat"
+  )
+})
+
+test_that("ds.select correctly passes `where`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "mtcars",
+    tidy_expr = list(where(is.numeric)),
+    newobj = "where",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("where", datasources = conns)[[1]],
+    colnames(mtcars)
+  )
+})
+
+test_that("ds.select correctly passes `num_range`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "num_range_df",
+    tidy_expr = list(num_range("x", 1:2)),
+    newobj = "num_range_res",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("num_range_res", datasources = conns)[[1]],
+    c("x1", "x2")
+  )
+})

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -5,9 +5,11 @@ require(dsTidyverse)
 require(dsBaseClient)
 
 data("mtcars")
-login_data <- .prepare_dslite(assign_method = "selectDS", tables = list(mtcars = mtcars))
+num_range_df <- data.frame(x1 = 1:5, x2 = 6:10, x3 = 11:15, y1 = 16:20, stringsAsFactors = FALSE)
+login_data <- .prepare_dslite(assign_method = "selectDS", tables = list(mtcars = mtcars, num_range_df = num_range_df))
 conns <- datashield.login(logins = login_data)
 datashield.assign.table(conns, "mtcars", "mtcars")
+datashield.assign.table(conns, "num_range_df", "num_range_df")
 
 test_that("ds.select fails with correct error message if data not present ", {
   skip_if_not_installed("dsBaseClient")
@@ -243,5 +245,20 @@ test_that("ds.select correctly passes strings with '='", {
   expect_equal(
     ds.colnames("equals", datasources = conns)[[1]],
     c("test", "cyl", "gear")
+  )
+})
+
+test_that("ds.select correctly passes `num_range`", {
+  skip_if_not_installed("dsBaseClient")
+  ds.select(
+    df.name = "num_range_df",
+    tidy_expr = list(num_range("x", 1:2)),
+    newobj = "num_range_res",
+    datasources = conns
+  )
+
+  expect_equal(
+    ds.colnames("num_range_res", datasources = conns)[[1]],
+    c("x1", "x2")
   )
 })

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -5,11 +5,9 @@ require(dsTidyverse)
 require(dsBaseClient)
 
 data("mtcars")
-num_range_df <- data.frame(x1 = 1:5, x2 = 6:10, x3 = 11:15, y1 = 16:20, stringsAsFactors = FALSE)
-login_data <- .prepare_dslite(assign_method = "selectDS", tables = list(mtcars = mtcars, num_range_df = num_range_df))
+login_data <- .prepare_dslite(assign_method = "selectDS", tables = list(mtcars = mtcars))
 conns <- datashield.login(logins = login_data)
 datashield.assign.table(conns, "mtcars", "mtcars")
-datashield.assign.table(conns, "num_range_df", "num_range_df")
 
 test_that("ds.select fails with correct error message if data not present ", {
   skip_if_not_installed("dsBaseClient")
@@ -35,96 +33,6 @@ test_that("ds.select correctly passes : ", {
   expect_equal(
     ds.colnames("mpg_drat", datasources = conns)[[1]],
     c("mpg", "cyl", "disp", "hp", "drat")
-  )
-})
-
-test_that("ds.select correctly passes `starts_with`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(starts_with("m")),
-    newobj = "starts",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("starts", datasources = conns)[[1]],
-    "mpg"
-  )
-})
-
-test_that("ds.select correctly passes `ends_with`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(ends_with("m")),
-    newobj = "ends",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("ends", datasources = conns)[[1]],
-    "am"
-  )
-})
-
-test_that("ds.select correctly passes `matches`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(matches("a")),
-    newobj = "matches",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("matches", datasources = conns)[[1]],
-    c("drat", "am", "gear", "carb")
-  )
-})
-
-test_that("ds.select correctly passes `everything`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(everything()),
-    newobj = "everything",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("everything", datasources = conns)[[1]],
-    colnames(mtcars)
-  )
-})
-
-test_that("ds.select correctly passes `last_col`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(last_col()),
-    newobj = "last",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("last", datasources = conns)[[1]],
-    "carb"
-  )
-})
-
-test_that("ds.select correctly passes `group_cols`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(group_cols()),
-    newobj = "group",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("group", datasources = conns)[[1]],
-    character(0)
   )
 })
 
@@ -173,36 +81,6 @@ test_that("ds.select correctly passes strings with '|'", {
   )
 })
 
-test_that("ds.select correctly passes `strings with `all_of`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(all_of(c("mpg", "cyl"))),
-    newobj = "all_of",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("all_of", datasources = conns)[[1]],
-    c("mpg", "cyl")
-  )
-})
-
-test_that("ds.select correctly passes strings with `any_of`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(any_of(c("mpg", "cyl"))),
-    newobj = "any_of",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("any_of", datasources = conns)[[1]],
-    c("mpg", "cyl")
-  )
-})
-
 test_that("ds.select correctly passes complex strings", {
   skip_if_not_installed("dsBaseClient")
   ds.select(
@@ -218,21 +96,6 @@ test_that("ds.select correctly passes complex strings", {
   )
 })
 
-test_that("ds.select correctly passes strings with `where`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "mtcars",
-    tidy_expr = list(where(is.numeric)),
-    newobj = "where",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("where", datasources = conns)[[1]],
-    colnames(mtcars)
-  )
-})
-
 test_that("ds.select correctly passes strings with '='", {
   skip_if_not_installed("dsBaseClient")
   ds.select(
@@ -245,20 +108,5 @@ test_that("ds.select correctly passes strings with '='", {
   expect_equal(
     ds.colnames("equals", datasources = conns)[[1]],
     c("test", "cyl", "gear")
-  )
-})
-
-test_that("ds.select correctly passes `num_range`", {
-  skip_if_not_installed("dsBaseClient")
-  ds.select(
-    df.name = "num_range_df",
-    tidy_expr = list(num_range("x", 1:2)),
-    newobj = "num_range_res",
-    datasources = conns
-  )
-
-  expect_equal(
-    ds.colnames("num_range_res", datasources = conns)[[1]],
-    c("x1", "x2")
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -75,11 +75,11 @@ test_that(".set_new_obj defaults to .data if no new object name is provided", {
 
 test_that(".get_encode_dictionary returns the expected encoding key", {
   expected_encode_list <- list(
-    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
+    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n", "%"),
     output = c(
       "$LB$", "$RB$", "$QUOTE$", "$COMMA$", "$SPACE$", "$EXCL$", "$AND$", "$OR$",
       "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$",
-      "$GT$", "$LT$", "$TILDE$", "$LINE$"
+      "$GT$", "$LT$", "$TILDE$", "$LINE$", "$PCT$"
     )
   )
   actual_encode_list <- .get_encode_dictionary()
@@ -136,7 +136,7 @@ test_that(".encode_tidy_eval correctly encodes strings with permitted values", {
 test_that(".encode_tidy_eval correctly encodes strings with unpermitted values", {
   encode_key <- .get_encode_dictionary()
   input_string <- "asd, qwe, wer == rew &}{}%"
-  expected_output <- "asd$COMMA$$SPACE$qwe$COMMA$$SPACE$wer$SPACE$$EQU$$EQU$$SPACE$rew$SPACE$$AND$}{}%"
+  expected_output <- "asd$COMMA$$SPACE$qwe$COMMA$$SPACE$wer$SPACE$$EQU$$EQU$$SPACE$rew$SPACE$$AND$}{}$PCT$"
   result <- .encode_tidy_eval(input_string, encode_key)
   expect_equal(result, expected_output)
 })


### PR DESCRIPTION
## Background

The `as.Date()` function with format arguments (e.g., `as.Date(date_str, "%d/%m/%Y")`) couldn't be passed through the DataSHIELD parser because `%` was not in the encoding dictionary. Additionally, test coverage for permitted functions in `ds.mutate` and `ds.select` was incomplete.

  ## What's changed

  #### Encoding
  - Added `%` to the encoding dictionary as `$PCT$`, enabling date format strings to pass through the parser.

  #### Test coverage
  - Created `test-mutate-permitted-functions.R` with end-to-end tests for all permitted functions in `ds.mutate`: math (`exp`, `sqrt`, `round`, `floor`, `ceiling`, `abs`, `scale`), stats (`mean`, `median`, `sd`, `var`), trig (`sin`,
   `cos`, `tan`, `asin`, `acos`, `atan`), type conversion (`as.character`, `as.integer`, `as.numeric`, `as.Date`), window (`lag`, `cumsum`), logical/conditional (`is.na`, `if_else`, `case_when`), and other (`desc`).
  - Added extensive `as.Date` format tests covering ISO, DMY, MDY, dash, slash, abbreviated month, compact, and dot formats.
  - Created `test-select-permitted-functions.R` with end-to-end tests for all tidyselect helpers: `starts_with`, `ends_with`, `matches`, `contains`, `everything`, `last_col`, `group_cols`, `all_of`, `any_of`, `where`, `num_range`.

  #### Refactoring
  - Moved tidyselect helper tests out of `test-select.R` into `test-select-permitted-functions.R`. `test-select.R` now only tests core behaviour (error handling, `:`, `&`, `!`, `|`, `=`, complex expressions).
  - Moved `as.Date` test from `test-mutate.R` to `test-mutate-permitted-functions.R`.

  #### Chore
  - CI fix: install knitr.
  - RoxygenNote version bump.

  ## How to test
  - [ ] Review code
  - [ ] Install dsTidyverse on a test server based on the `fix/package-env` branch
  - [ ] Run all tests from `test-mutate.R`, `test-select.R`, `test-mutate-specific-functions.R` and `test-select-specific-functions.R` (excluding the dsLite setup at the top).